### PR TITLE
Добавлена возможность отправки метрик через pushgateway

### DIFF
--- a/examples_settings.yaml
+++ b/examples_settings.yaml
@@ -76,5 +76,12 @@ RAC:
   Login: ""         # Не обязательный параметр
   Pass: ""          # Не обязательный параметр
 
+Pushgateway: # Обязательный параметр
+  Enable: true
+  URL: "http://localhost:8000"
+  Interval: 30
+  GroupingLabel: "instance"
+  GroupingValue: "example instance"
+
 LogDir:        # Если на задан логи будут писаться в каталог с исполняемым файлом
 LogLevel:  5   # Уровень логирования от 2 до 5, где 2 - ошибка, 3 - предупреждение, 4 - информация, 5 - дебаг

--- a/explorers/SessionsData.go
+++ b/explorers/SessionsData.go
@@ -104,7 +104,7 @@ FOR:
 					if val, err := strconv.Atoi(item["duration-current"]); err == nil && val > 0 {
 						exp.summary.WithLabelValues(host, basename, item["user-name"], item["session-id"], "durationcurrent", item["current-service-name"], appid, startedAt.Format(timeFormatOut)).Observe(float64(val))
 					}
-					if val, err := strconv.Atoi(item["duration current-dbms"]); err == nil && val > 0 {
+					if val, err := strconv.Atoi(item["duration-current-dbms"]); err == nil && val > 0 {
 						exp.summary.WithLabelValues(host, basename, item["user-name"], item["session-id"], "durationcurrentdbms", item["current-service-name"], appid, startedAt.Format(timeFormatOut)).Observe(float64(val))
 					}
 					if val, err := strconv.Atoi(item["duration-all"]); err == nil && val > 0 {
@@ -127,6 +127,13 @@ FOR:
 
 					if val, err := strconv.Atoi(item["calls-all"]); err == nil && val > 0 {
 						exp.summary.WithLabelValues(host, basename, item["user-name"], item["session-id"], "callsall", item["current-service-name"], appid, startedAt.Format(timeFormatOut)).Observe(float64(val))
+					}
+
+					if val, err := strconv.Atoi(item["blocked-by-dbms"]); err == nil && val > 0 {
+						exp.summary.WithLabelValues(host, basename, item["user-name"], item["session-id"], "blockedbydbms", item["current-service-name"], appid, startedAt.Format(timeFormatOut)).Observe(float64(val))
+					}
+					if val, err := strconv.Atoi(item["blocked-by-ls"]); err == nil && val > 0 {
+						exp.summary.WithLabelValues(host, basename, item["user-name"], item["session-id"], "blockedby1s", item["current-service-name"], appid, startedAt.Format(timeFormatOut)).Observe(float64(val))
 					}
 
 					if !lastActiveAt.IsZero() {

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -41,6 +41,14 @@ type Settings struct {
 		Pass  string `yaml:"Pass"`
 	} `yaml:"RAC"`
 
+	Pushgateway *struct {
+		Enable        bool   `yaml:"Enable"`
+		URL           string `yaml:"URL"`
+		Interval      int    `yaml:"Interval"`
+		GroupingLabel string `yaml:"GroupingLabel"`
+		GroupingValue string `yaml:"GroupingValue"`
+	} `yaml:"Pushgateway"`
+
 	mx *sync.RWMutex `yaml:"-"`
 	// login, pass string        `yaml:"-"`
 	bases []Bases `yaml:"-"`


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add optional, configurable Prometheus Pushgateway integration that periodically pushes metrics using the default registry.
> 
> - **Metrics/Pushgateway**:
>   - Add `PushGatewayService` with periodic push to configured Pushgateway using OpenMetrics format.
>   - Wire into app lifecycle: initialize in `app.Init` when `settings.Pushgateway.Enable` is true and start via `app.Start()`.
>   - Use default Prometheus registry (`prometheus.DefaultRegisterer.(*prometheus.Registry)`).
> - **Configuration**:
>   - Extend `settings.Settings` with `Pushgateway` block: `Enable`, `URL`, `Interval`, `GroupingLabel`, `GroupingValue`.
>   - Update `examples_settings.yaml` with a sample `Pushgateway` configuration.
> - **HTTP/Exports**:
>   - Keep existing endpoints; metrics also pushed to Pushgateway at the configured interval.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9b181b2dcac4847338f514ec618ac08c8d9be80. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->